### PR TITLE
Add second pass for DataTypes

### DIFF
--- a/Jumoo.uSync.BackOffice/Handlers/DataTypeMappingHandler.cs
+++ b/Jumoo.uSync.BackOffice/Handlers/DataTypeMappingHandler.cs
@@ -1,0 +1,112 @@
+﻿
+
+namespace Jumoo.uSync.BackOffice.Handlers
+{
+    using System;
+    using System.IO;
+    using System.Xml.Linq;
+    using System.Collections.Generic;
+
+    using Umbraco.Core;
+    using Umbraco.Core.Models;
+    using Umbraco.Core.Services;
+    using Umbraco.Core.Logging;
+
+    using Jumoo.uSync.Core;
+    using Jumoo.uSync.BackOffice.Helpers;
+    using Core.Extensions;
+
+    public class DataTypeMappingHandler : uSyncBaseHandler<IDataTypeDefinition>, ISyncHandler
+    {
+        public string Name { get { return "uSync: DataTypeMappingHandler"; } }
+        public int Priority { get { return uSyncConstants.Priority.DataTypeMappings; } }
+        public string SyncFolder { get { return Constants.Packaging.DataTypeNodeName; } }
+
+        public void RegisterEvents()
+        {
+            //No events to register
+        }
+
+        IDataTypeService _dataTypeService;
+        public DataTypeMappingHandler()
+        {
+            _dataTypeService = ApplicationContext.Current.Services.DataTypeService;
+        }
+
+        public override SyncAttempt<IDataTypeDefinition> Import(string filePath, bool force = false)
+        {
+            IDataTypeDefinition item = null;
+
+            var node = XElement.Load(filePath);
+
+            var key = node.Attribute("Key").ValueOrDefault(Guid.Empty);
+            if (key != Guid.Empty)
+            {
+                item = _dataTypeService.GetDataTypeDefinitionById(key);
+            }
+
+            return SyncAttempt<IDataTypeDefinition>.Succeed(Path.GetFileName(filePath), item ,ChangeType.Update);
+        }
+
+        /// <summary>
+        ///  second pass placeholder, some things require a second pass
+        ///  (doctypes for structures to be in place)
+        /// 
+        ///  they just override this function to do their thing.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <param name="item"></param>
+        public override void ImportSecondPass(string file, IDataTypeDefinition item)
+        {
+            XElement node = XElement.Load(file);
+            uSyncCoreContext.Instance.DataTypeMappingSerializer.DesearlizeSecondPass(item, node);
+        }
+
+        public override uSyncAction DeleteItem(Guid key, string keyString)
+        {
+            IDataTypeDefinition item = null;
+            if (key != Guid.Empty)
+                item = _dataTypeService.GetDataTypeDefinitionById(key);
+
+            /* delete only by key 
+            if (item == null && !string.IsNullOrEmpty(keyString))
+                item = _dataTypeService.GetDataTypeDefinitionByName(keyString);
+            */
+
+            if (item != null)
+            {
+                LogHelper.Info<DataTypeHandler>("Deleting datatype: {0}", () => item.Name);
+                _dataTypeService.Delete(item);
+                return uSyncAction.SetAction(true, keyString, typeof(IDataTypeDefinition), ChangeType.Delete, "Removed");
+            }
+
+            return uSyncAction.Fail(keyString, typeof(IDataTypeDefinition), ChangeType.Delete, "Not found");
+        }
+
+        public IEnumerable<uSyncAction> ExportAll(string folder)
+        {
+            LogHelper.Info<DataTypeHandler>("Exporting all DataTypes");
+
+            //Do nothing as the datatypes will have been exported by the other handler
+            return new List<uSyncAction>();
+        }
+
+        public uSyncAction ExportToDisk(IDataTypeDefinition item, string folder)
+        {
+            return uSyncAction.Fail(Path.GetFileName(folder), typeof(IDataTypeDefinition), "item already exported");
+        }
+
+        public override uSyncAction ReportItem(string file)
+        {
+            LogHelper.Debug<DataTypeHandler>("Report: {0}", () => file);
+
+            var node = XElement.Load(file);
+
+            LogHelper.Debug<DataTypeHandler>("Report: {0}", () => node.ToString());
+
+            var update = uSyncCoreContext.Instance.DataTypeSerializer.IsUpdate(node);
+            return uSyncActionHelper<IDataTypeDefinition>.ReportAction(update, node.NameFromNode());
+        }
+
+    }
+}

--- a/Jumoo.uSync.BackOffice/Jumoo.uSync.BackOffice.csproj
+++ b/Jumoo.uSync.BackOffice/Jumoo.uSync.BackOffice.csproj
@@ -71,6 +71,7 @@
     <Compile Include="BackOffice.cs" />
     <Compile Include="Controllers\uSyncBackOfficeController.cs" />
     <Compile Include="Handlers\ContentTypeHandler.cs" />
+    <Compile Include="Handlers\DataTypeMappingHandler.cs" />
     <Compile Include="Handlers\DataTypeHandler.cs" />
     <Compile Include="Handlers\DictionaryHandler.cs" />
     <Compile Include="Handlers\LanguageHandler.cs" />

--- a/Jumoo.uSync.BackOffice/uSyncBackOffice.Config
+++ b/Jumoo.uSync.BackOffice/uSyncBackOffice.Config
@@ -40,5 +40,6 @@
     <HandlerConfig Name="uSync: LanguageHandler" Enabled="true" />
     <HandlerConfig Name="uSync: DictionaryHandler" Enabled="true" />
     <HandlerConfig Name="uSync: MacroHandler" Enabled="true" />
+    <HandlerConfig Name="uSync: DataTypeMappingHandler" Enabled="true" />
   </Handlers>
 </uSyncBackOfficeSettings>

--- a/Jumoo.uSync.BackOffice/uSyncConstants.cs
+++ b/Jumoo.uSync.BackOffice/uSyncConstants.cs
@@ -21,6 +21,8 @@ namespace Jumoo.uSync.BackOffice
 
             public const int Media = USYNC_RESERVED_LOWER + 200;
             public const int Content = USYNC_RESERVED_LOWER + 210;
+
+            public const int DataTypeMappings = USYNC_RESERVED_LOWER + 220;
         }
     }
 

--- a/Jumoo.uSync.Core/Helpers/uSyncTreeWalker.cs
+++ b/Jumoo.uSync.Core/Helpers/uSyncTreeWalker.cs
@@ -25,9 +25,9 @@ namespace Jumoo.uSync.Core.Helpers
             _type = type;
         }
 
-        public string GetPathFromId(int id)
+        public string GetPathFromId(int id, UmbracoObjectTypes type)
         {
-            var item = _entityService.Get(id);
+            var item = _entityService.Get(id, type);
             if (item != null && !item.Trashed)
                 return GetPath(item);
 

--- a/Jumoo.uSync.Core/Helpers/uSyncValueMapper.cs
+++ b/Jumoo.uSync.Core/Helpers/uSyncValueMapper.cs
@@ -52,7 +52,7 @@ namespace Jumoo.uSync.Core.Helpers
             bool isMapped = false;
 
             var ids = GetValueMatchSubstring(value);
-
+            
             foreach (Match match in Regex.Matches(ids, _settings.IdRegex))
             {
                 string mappingType = _settings.MappingType.ToLower();
@@ -66,11 +66,9 @@ namespace Jumoo.uSync.Core.Helpers
                     {
                         case "content":
                             mappedValue = ContentToGeneric(id);
-                            if (string.IsNullOrEmpty(mappedValue))
-                            {
-                                destinationType = "Media";
-                                mappedValue = MediaToGeneric(id);
-                            }
+                            break;
+                        case "media":
+                            mappedValue = MediaToGeneric(id);
                             break;
                         case "tab":
                             mappedValue = TabToGeneric(id);
@@ -85,7 +83,7 @@ namespace Jumoo.uSync.Core.Helpers
 
                     if (!string.IsNullOrEmpty(mappedValue))
                     {
-                        AddToNode(id, mappedValue, type, mapId);
+                        AddToNode(id, mappedValue, destinationType, mapId);
                         isMapped = true;
                         break;
                     }
@@ -173,11 +171,11 @@ namespace Jumoo.uSync.Core.Helpers
 
         private string ContentToGeneric(string id)
         {
-            uSyncTreeWalker walker = new uSyncTreeWalker(UmbracoObjectTypes.ContentItem);
+            uSyncTreeWalker walker = new uSyncTreeWalker(UmbracoObjectTypes.Document);
 
             int contentId;
             if (int.TryParse(id, out contentId))
-                return walker.GetPathFromId(contentId);
+                return walker.GetPathFromId(contentId, UmbracoObjectTypes.Document);
 
             return string.Empty;
         }
@@ -188,7 +186,7 @@ namespace Jumoo.uSync.Core.Helpers
 
             int contentId;
             if (int.TryParse(id, out contentId))
-                return walker.GetPathFromId(contentId);
+                return walker.GetPathFromId(contentId, UmbracoObjectTypes.Media);
 
             return string.Empty;
         }
@@ -258,7 +256,7 @@ namespace Jumoo.uSync.Core.Helpers
 
                 var valueSubString = GetValueMatchSubstring(value);
 
-                var localId = GetMappedId(id, value, type);
+                var localId = GetMappedId(id, val, type);
 
                 // all the zz swapping here, to stop false positives...
                 Regex exsitingRegEx = new Regex(string.Format("{0}(?!:zzusync)", localId));
@@ -311,7 +309,7 @@ namespace Jumoo.uSync.Core.Helpers
 
         private string ContentToId(string id, string value)
         {
-            var walker = new uSyncTreeWalker(UmbracoObjectTypes.ContentItem);
+            var walker = new uSyncTreeWalker(UmbracoObjectTypes.Document);
             var mappedId = walker.GetIdFromPath(value);
             return (mappedId != -1) ? mappedId.ToString() : id;
         }

--- a/Jumoo.uSync.Core/Jumoo.uSync.Core.csproj
+++ b/Jumoo.uSync.Core/Jumoo.uSync.Core.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Serializers\ContentTypeBaseSerializer.cs" />
     <Compile Include="Serializers\ContentTypeSerializer.cs" />
     <Compile Include="Serializers\DataTypeSerializer.cs" />
+    <Compile Include="Serializers\DataTypeSyncBaseSerializer.cs" />
     <Compile Include="Serializers\DictionarySerializer.cs" />
     <Compile Include="Serializers\LanguageSerializer.cs" />
     <Compile Include="Serializers\MacroSerializer.cs" />

--- a/Jumoo.uSync.Core/Serializers/DataTypeSyncBaseSerializer.cs
+++ b/Jumoo.uSync.Core/Serializers/DataTypeSyncBaseSerializer.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Jumoo.uSync.Core.Extensions;
+using Jumoo.uSync.Core.Interfaces;
+using Umbraco.Core.Models;
+
+namespace Jumoo.uSync.Core.Serializers
+{
+    public abstract class DataTypeSyncBaseSerializer : ISyncSerializerTwoPass<IDataTypeDefinition>
+    {
+        internal readonly string _itemType;
+
+        public DataTypeSyncBaseSerializer(string itemType)
+        {
+            _itemType = itemType;
+        }
+
+        public SyncAttempt<XElement> Serialize(IDataTypeDefinition item)
+        {
+            return SerializeCore(item);
+        }
+
+        public SyncAttempt<IDataTypeDefinition> Deserialize(XElement node, bool forceUpdate, bool onePass)
+        {
+            return DeSerialize(node, forceUpdate);
+        }
+
+        public SyncAttempt<IDataTypeDefinition> DeSerialize(XElement node, bool forceUpdate = false)
+        {
+            if (node.Name.LocalName != _itemType)
+                throw new ArgumentException("XML not valid for type: " + _itemType);
+
+            if (forceUpdate || IsUpdate(node))
+            {
+                return DeserializeCore(node);
+            }
+
+            return SyncAttempt<IDataTypeDefinition>.Succeed(node.NameFromNode(), null, ChangeType.NoChange);
+        }
+        
+        public SyncAttempt<IDataTypeDefinition> DesearlizeSecondPass(IDataTypeDefinition item, XElement node, bool onePass)
+        {
+            return DesearlizeSecondPass(item, node);
+        }
+
+        public SyncAttempt<IDataTypeDefinition> DesearlizeSecondPass(IDataTypeDefinition item, XElement node)
+        {
+            return DesearlizeSecondPassCore(item, node);
+        }
+
+        virtual public bool IsUpdate(XElement node)
+        {
+            return true;
+        }
+
+        abstract internal SyncAttempt<XElement> SerializeCore(IDataTypeDefinition item);
+        abstract internal SyncAttempt<IDataTypeDefinition> DeserializeCore(XElement node);
+        abstract internal SyncAttempt<IDataTypeDefinition> DesearlizeSecondPassCore(IDataTypeDefinition item, XElement node);
+    }
+}

--- a/Jumoo.uSync.Core/uSyncContext.cs
+++ b/Jumoo.uSync.Core/uSyncContext.cs
@@ -30,7 +30,8 @@ namespace Jumoo.uSync.Core
         public ISyncSerializer<IDictionaryItem> DictionarySerializer { get; private set; }
 
         public ISyncSerializer<IMacro> MacroSerializer { get; private set; }
-        public ISyncSerializer<IDataTypeDefinition> DataTypeSerializer { get; private set; }
+        public ISyncSerializerTwoPass<IDataTypeDefinition> DataTypeSerializer { get; private set; }
+        public ISyncSerializerTwoPass<IDataTypeDefinition> DataTypeMappingSerializer { get; private set; }
 
         public ISyncSerializerWithParent<IContent> ContentSerializer { get; private set; }
         public ISyncSerializerWithParent<IMedia> MediaSerializer { get; private set; }
@@ -54,7 +55,11 @@ namespace Jumoo.uSync.Core
             DictionarySerializer = new DictionarySerializer(Constants.Packaging.DictionaryItemNodeName);
 
             MacroSerializer = new MacroSerializer(Constants.Packaging.MacroNodeName);
-            DataTypeSerializer = new DataTypeSerializer(Constants.Packaging.DataTypeNodeName);
+
+            var dataTypeSerializer = new DataTypeSerializer(Constants.Packaging.DataTypeNodeName);
+
+            DataTypeSerializer = dataTypeSerializer;
+            DataTypeMappingSerializer = dataTypeSerializer;
 
             ContentSerializer = new ContentSerializer();
             MediaSerializer = new MediaSerializer();

--- a/Jumoo.uSync.Core/uSyncCore.Config
+++ b/Jumoo.uSync.Core/uSyncCore.Config
@@ -34,7 +34,7 @@
     <!-- multinode tree picker, has an id in the json -->
     <uSyncValueMapperSettings>
       <DataTypeId>Umbraco.MultiNodeTreePicker</DataTypeId>
-      <MappingType>content</MappingType>
+      <MappingType>content,media</MappingType>
       <ValueStorageType>json</ValueStorageType>
       <ValueAlias>startNode</ValueAlias>
       <PropertyName>id</PropertyName>
@@ -55,7 +55,15 @@
     <!-- media picker (for mappings media is also content) -->
     <uSyncValueMapperSettings>
       <DataTypeId>Umbraco.MediaPicker</DataTypeId>
-      <MappingType>content</MappingType>
+      <MappingType>media</MappingType>
+      <ValueStorageType>text</ValueStorageType>
+      <ValueAlias>startNodeId</ValueAlias>
+    </uSyncValueMapperSettings>
+
+    <!-- multiple media picker (for mappings media is also content) -->
+    <uSyncValueMapperSettings>
+      <DataTypeId>Umbraco.MultipleMediaPicker</DataTypeId>
+      <MappingType>media</MappingType>
       <ValueStorageType>text</ValueStorageType>
       <ValueAlias>startNodeId</ValueAlias>
     </uSyncValueMapperSettings>

--- a/Umbraco.Site/Config/uSyncBackOffice.Config
+++ b/Umbraco.Site/Config/uSyncBackOffice.Config
@@ -40,5 +40,6 @@
     <HandlerConfig Name="uSync: LanguageHandler" Enabled="true" />
     <HandlerConfig Name="uSync: DictionaryHandler" Enabled="true" />
     <HandlerConfig Name="uSync: MacroHandler" Enabled="true" />
+    <HandlerConfig Name="uSync: DataTypeMappingHandler" Enabled="true" />
   </Handlers>
 </uSyncBackOfficeSettings>

--- a/Umbraco.Site/Config/uSyncCore.config
+++ b/Umbraco.Site/Config/uSyncCore.config
@@ -34,7 +34,7 @@
     <!-- multinode tree picker, has an id in the json -->
     <uSyncValueMapperSettings>
       <DataTypeId>Umbraco.MultiNodeTreePicker</DataTypeId>
-      <MappingType>content</MappingType>
+      <MappingType>content,media</MappingType>
       <ValueStorageType>json</ValueStorageType>
       <ValueAlias>startNode</ValueAlias>
       <PropertyName>id</PropertyName>
@@ -55,7 +55,15 @@
     <!-- media picker (for mappings media is also content) -->
     <uSyncValueMapperSettings>
       <DataTypeId>Umbraco.MediaPicker</DataTypeId>
-      <MappingType>content</MappingType>
+      <MappingType>media</MappingType>
+      <ValueStorageType>text</ValueStorageType>
+      <ValueAlias>startNodeId</ValueAlias>
+    </uSyncValueMapperSettings>
+
+    <!-- multiple media picker (for mappings media is also content) -->
+    <uSyncValueMapperSettings>
+      <DataTypeId>Umbraco.MultipleMediaPicker</DataTypeId>
+      <MappingType>media</MappingType>
       <ValueStorageType>text</ValueStorageType>
       <ValueAlias>startNodeId</ValueAlias>
     </uSyncValueMapperSettings>


### PR DESCRIPTION
Made DataTypeSerializer into a two-pass serializer with the second pass used to map Ids that are in the content or media trees. #14 

Introduced DataTypeMappingHandler which runs the second pass after the Content and Media have been imported.

Changed multinodetreepicker mapping to include media
Added Umbraco.MultipleMediaPicker mapping

Updated uSyncTreeWalker and uSyncValueMapper to provide a clear distinction between media and content and allow for correct mapping of MNTP and other pickers that can map from either tree
