### PR TITLE
Archetype support

### DIFF
--- a/Jumoo.uSync.Archetype/ArchetypeContentMapper.cs
+++ b/Jumoo.uSync.Archetype/ArchetypeContentMapper.cs
@@ -1,0 +1,99 @@
+﻿using System.Linq;
+using Archetype.Models;
+using Jumoo.uSync.Core;
+using Jumoo.uSync.Core.Mappers;
+using Newtonsoft.Json;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+
+namespace Jumoo.uSync.Archetype
+{
+    public class ArchetypeContentMapper : IContentMapper
+    {
+        public ArchetypeContentMapper()
+        {
+            _dataTypeService = ApplicationContext.Current.Services.DataTypeService;
+        }
+
+        private readonly IDataTypeService _dataTypeService;
+
+        public string GetExportValue(int dataTypeDefinitionId, string value)
+        {
+            // We need to retrieve the datatype associated with the property so that we can parse the fieldset
+            // then we will go through each item in the fieldset and if there is a mapper associated with that item's datatype
+            // we should map the property value
+
+            string archetypeConfig = _dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinitionId).PreValuesAsDictionary["archetypeConfig"].Value;
+
+            var config = JsonConvert.DeserializeObject<ArchetypePreValue>(archetypeConfig);
+
+            var typedContent = JsonConvert.DeserializeObject<ArchetypeModel>(value);
+
+            foreach (ArchetypePreValueFieldset fieldSet in config.Fieldsets)
+            {
+                foreach (ArchetypePreValueProperty property in fieldSet.Properties)
+                {
+                    IDataTypeDefinition dataType = _dataTypeService.GetDataTypeDefinitionById(property.DataTypeGuid);
+
+                    uSyncContentMapping mapping =
+                        uSyncCoreContext.Instance.Configuration.Settings.ContentMappings.SingleOrDefault(x => x.EditorAlias == dataType.PropertyEditorAlias);
+
+                    if (mapping != null)
+                    {
+                        IContentMapper mapper = ContentMapperFactory.GetMapper(mapping);
+
+                        if (mapper != null)
+                        {
+                            typedContent.Fieldsets.AsQueryable()
+                                        .SelectMany(fs => fs.Properties)
+                                        .Where(p => p.Alias == property.Alias)
+                                        .ForEach(pm => pm.Value = mapper.GetExportValue(dataType.Id, pm.Value.ToString()));
+                        }
+                    }
+                }
+            }
+
+            return typedContent.SerializeForPersistence();
+        }
+
+        public string GetImportValue(int dataTypeDefinitionId, string content)
+        {
+            // We need to retrieve the datatype associated with the property so that we can parse the fieldset
+            // then we will go through each item in the fieldset and if there is a mapper associated with that item's datatype
+            // we should pull out the property value and map it
+
+            string archetypeConfig = _dataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinitionId).PreValuesAsDictionary["archetypeConfig"].Value;
+
+            var config = JsonConvert.DeserializeObject<ArchetypePreValue>(archetypeConfig);
+
+            var typedContent = JsonConvert.DeserializeObject<ArchetypeModel>(content);
+
+            foreach (ArchetypePreValueFieldset fieldSet in config.Fieldsets)
+            {
+                foreach (ArchetypePreValueProperty property in fieldSet.Properties)
+                {
+                    IDataTypeDefinition dataType = _dataTypeService.GetDataTypeDefinitionById(property.DataTypeGuid);
+
+                    uSyncContentMapping mapping =
+                        uSyncCoreContext.Instance.Configuration.Settings.ContentMappings.SingleOrDefault(x => x.EditorAlias == dataType.PropertyEditorAlias);
+
+                    if (mapping != null)
+                    {
+                        IContentMapper mapper = ContentMapperFactory.GetMapper(mapping);
+
+                        if (mapper != null)
+                        {
+                            typedContent.Fieldsets.AsQueryable()
+                                        .SelectMany(fs => fs.Properties)
+                                        .Where(p => p.Alias == property.Alias)
+                                        .ForEach(pm => pm.Value = mapper.GetImportValue(dataType.Id, pm.Value.ToString()));
+                        }
+                    }
+                }
+            }
+
+            return typedContent.SerializeForPersistence();
+        }
+    }
+}

--- a/Jumoo.uSync.Archetype/Jumoo.uSync.Archetype.csproj
+++ b/Jumoo.uSync.Archetype/Jumoo.uSync.Archetype.csproj
@@ -1,0 +1,249 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{DB2DDA62-9CFC-4052-8C06-70AC63F4C431}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Jumoo.uSync.Archetype</RootNamespace>
+    <AssemblyName>Jumoo.uSync.Archetype</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Archetype, Version=1.12.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Archetype.Binaries.1.12.2\lib\net40\Archetype.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="AutoMapper, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.3.0.0\lib\net40\AutoMapper.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="AutoMapper.Net4, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoMapper.3.0.0\lib\net40\AutoMapper.Net4.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="businesslogic, Version=1.0.5529.18523, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\businesslogic.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientDependency.Core, Version=1.8.2.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency.1.8.2.1\lib\net45\ClientDependency.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ClientDependency.Core.Mvc, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ClientDependency-Mvc.1.8.0.0\lib\net45\ClientDependency.Core.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="cms, Version=1.0.5529.18524, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\cms.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="controls, Version=1.0.5529.18525, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\controls.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="CookComputing.XmlRpcV2, Version=2.5.0.0, Culture=neutral, PublicKeyToken=a7d6e17aa302004d, processorArchitecture=MSIL">
+      <HintPath>..\packages\xmlrpcnet.2.5.0\lib\net20\CookComputing.XmlRpcV2.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Examine, Version=0.1.60.2941, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Examine.0.1.60.2941\lib\Examine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="HtmlAgilityPack, Version=1.4.6.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
+      <HintPath>..\packages\HtmlAgilityPack.1.4.6\lib\Net45\HtmlAgilityPack.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ImageProcessor, Version=1.9.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.1.9.5.0\lib\ImageProcessor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="ImageProcessor.Web, Version=3.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ImageProcessor.Web.3.3.1.0\lib\net45\ImageProcessor.Web.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="interfaces, Version=1.0.5529.18522, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\interfaces.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="log4net, Version=1.2.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\log4net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Lucene.Net, Version=2.9.4.1, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lucene.Net.2.9.4.1\lib\net40\Lucene.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.ApplicationBlocks.Data, Version=1.0.1559.20655, Culture=neutral">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\Microsoft.ApplicationBlocks.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Web.Mvc.FixedDisplayModes, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.FixedDisplayModes.1.0.1\lib\net40\Microsoft.Web.Mvc.FixedDisplayModes.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MiniProfiler, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b44f9351044011a3, processorArchitecture=MSIL">
+      <HintPath>..\packages\MiniProfiler.2.1.0\lib\net40\MiniProfiler.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="MySql.Data, Version=6.6.5.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
+      <HintPath>..\packages\MySql.Data.6.6.5\lib\net40\MySql.Data.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SQLCE4Umbraco, Version=1.0.5529.18524, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\SQLCE4Umbraco.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.SqlServerCe, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\System.Data.SqlServerCe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Data.SqlServerCe.Entity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\System.Data.SqlServerCe.Entity.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.4.0.30506.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.Helpers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.4.0.30506.0\lib\net40\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http.WebHost, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.4.0.30506.0\lib\net40\System.Web.Http.WebHost.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Mvc, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Mvc.4.0.30506.0\lib\net40\System.Web.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Razor.2.0.20710.0\lib\net40\System.Web.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Deployment, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Deployment.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.20710.0\lib\net40\System.Web.WebPages.Razor.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="TidyNet, Version=1.0.0.0, Culture=neutral">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\TidyNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="umbraco, Version=1.0.5529.18525, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\umbraco.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Umbraco.Core, Version=1.0.5529.18522, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\Umbraco.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="umbraco.DataLayer, Version=1.0.5529.18523, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\umbraco.DataLayer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="umbraco.editorControls, Version=1.0.5529.18526, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\umbraco.editorControls.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="umbraco.MacroEngines, Version=1.0.5529.18526, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\umbraco.MacroEngines.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="umbraco.providers, Version=1.0.5529.18525, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\umbraco.providers.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Umbraco.Web.UI, Version=1.0.5529.18527, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\Umbraco.Web.UI.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="UmbracoExamine, Version=0.7.0.18524, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\UmbracoExamine.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="UrlRewritingNet.UrlRewriter, Version=2.0.60829.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\UmbracoCms.Core.7.2.2\lib\UrlRewritingNet.UrlRewriter.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ArchetypeContentMapper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Jumoo.uSync.Core\Jumoo.uSync.Core.csproj">
+      <Project>{B356FE24-54B5-462F-B6FE-EE99A38695D7}</Project>
+      <Name>Jumoo.uSync.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Jumoo.uSync.Archetype/Properties/AssemblyInfo.cs
+++ b/Jumoo.uSync.Archetype/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Jumoo.uSync.Archetype")]
+[assembly: AssemblyDescription("ContentMapper to allow uSync to handle Archetype properties")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Jumoo.uSync.Archetype")]
+[assembly: AssemblyCopyright("Mozila Open Licence 2.0")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("db2dda62-9cfc-4052-8c06-70ac63f4c431")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Jumoo.uSync.Archetype/app.config
+++ b/Jumoo.uSync.Archetype/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Jumoo.uSync.Archetype/packages.config
+++ b/Jumoo.uSync.Archetype/packages.config
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Archetype.Binaries" version="1.12.2" targetFramework="net451" />
+  <package id="AutoMapper" version="3.0.0" targetFramework="net451" />
+  <package id="ClientDependency" version="1.8.2.1" targetFramework="net451" />
+  <package id="ClientDependency-Mvc" version="1.8.0.0" targetFramework="net451" />
+  <package id="Examine" version="0.1.60.2941" targetFramework="net451" />
+  <package id="HtmlAgilityPack" version="1.4.6" targetFramework="net451" />
+  <package id="ImageProcessor" version="1.9.5.0" targetFramework="net451" />
+  <package id="ImageProcessor.Web" version="3.3.1.0" targetFramework="net451" />
+  <package id="Lucene.Net" version="2.9.4.1" targetFramework="net451" />
+  <package id="Microsoft.AspNet.Mvc" version="4.0.30506.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.Mvc.FixedDisplayModes" version="1.0.1" targetFramework="net451" />
+  <package id="Microsoft.AspNet.Razor" version="2.0.20710.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi" version="4.0.30506.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="4.0.30506.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="4.0.30506.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="4.0.30506.0" targetFramework="net451" />
+  <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net451" />
+  <package id="Microsoft.Net.Http" version="2.0.20710.0" targetFramework="net451" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net451" />
+  <package id="MiniProfiler" version="2.1.0" targetFramework="net451" />
+  <package id="MySql.Data" version="6.6.5" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net451" />
+  <package id="SharpZipLib" version="0.86.0" targetFramework="net451" />
+  <package id="UmbracoCms.Core" version="7.2.2" targetFramework="net451" />
+  <package id="xmlrpcnet" version="2.5.0" targetFramework="net451" />
+</packages>

--- a/Jumoo.uSync.BackOffice.UI/Web.config
+++ b/Jumoo.uSync.BackOffice.UI/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433

--- a/Jumoo.uSync.Core/Jumoo.uSync.Core.csproj
+++ b/Jumoo.uSync.Core/Jumoo.uSync.Core.csproj
@@ -286,6 +286,7 @@
     <Compile Include="Mappers\ContentDataTypeKeyMapper.cs" />
     <Compile Include="Mappers\ContentDataTypeMapper.cs" />
     <Compile Include="Mappers\ContentIdMapping.cs" />
+    <Compile Include="Mappers\ContentMapperFactory.cs" />
     <Compile Include="Mappers\IContentMapper.cs" />
     <Compile Include="Serializers\ContentBaseSerializer.cs" />
     <Compile Include="Serializers\ContentSerializer.cs" />

--- a/Jumoo.uSync.Core/Mappers/ContentDataTypeKeyMapper.cs
+++ b/Jumoo.uSync.Core/Mappers/ContentDataTypeKeyMapper.cs
@@ -19,13 +19,13 @@ namespace Jumoo.uSync.Core.Mappers
         ///  takes a key (or commaseperated list of keys) and 
         ///  turns it into an alias (or commaseperated list of aliases)
         /// </summary>
-        public string GetExportValue(PropertyType propType, string value)
+        public string GetExportValue(int dataTypeDefinitionId, string value)
         {
             if (string.IsNullOrWhiteSpace(value))
                 return value;
 
             var prevalues =
-                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(propType.DataTypeDefinitionId).PreValuesAsDictionary;
+                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinitionId).PreValuesAsDictionary;
             if (prevalues != null && prevalues.Count > 0)
             {
                 var values = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
@@ -58,12 +58,12 @@ namespace Jumoo.uSync.Core.Mappers
             return value;
         }
 
-        public string GetImportValue(PropertyType propType, string content)
+        public string GetImportValue(int dataTypeDefinitionId, string content)
         {
-            LogHelper.Debug<ContentDataTypeKeyMapper>("Mapping a datatype: {0} {1}", () => propType.DataTypeDefinitionId, () => content);
+            LogHelper.Debug<ContentDataTypeKeyMapper>("Mapping a datatype: {0} {1}", () => dataTypeDefinitionId, () => content);
 
             var prevalues =
-                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(propType.DataTypeDefinitionId)
+                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinitionId)
                                   .PreValuesAsDictionary;
 
             if (prevalues != null && prevalues.Count > 0)

--- a/Jumoo.uSync.Core/Mappers/ContentDataTypeMapper.cs
+++ b/Jumoo.uSync.Core/Mappers/ContentDataTypeMapper.cs
@@ -18,13 +18,13 @@ namespace Jumoo.uSync.Core.Mappers
         ///  takes a list of value names and returns a list 
         ///  of alias values 
         /// </summary>
-        public string GetExportValue(PropertyType propType, string value)
+        public string GetExportValue(int dataTypeDefinitionId, string value)
         {
             if (string.IsNullOrWhiteSpace(value))
                 return value;
 
             var prevalues =
-                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(propType.DataTypeDefinitionId).PreValuesAsDictionary;
+                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinitionId).PreValuesAsDictionary;
 
             if (prevalues != null && prevalues.Count > 0)
             {
@@ -55,12 +55,12 @@ namespace Jumoo.uSync.Core.Mappers
             return value;
         }
 
-        public string GetImportValue(PropertyType propType, string content)
+        public string GetImportValue(int dataTypeDefinitionId, string content)
         {
-            LogHelper.Debug<ContentDataTypeMapper>("Mapping a datatype: {0} {1}", () => propType.DataTypeDefinitionId, () => content);
+            LogHelper.Debug<ContentDataTypeMapper>("Mapping a datatype: {0} {1}", () => dataTypeDefinitionId, () => content);
 
             var prevalues =
-                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(propType.DataTypeDefinitionId)
+                ApplicationContext.Current.Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeDefinitionId)
                                   .PreValuesAsDictionary;
 
             if (prevalues != null && prevalues.Count > 0)

--- a/Jumoo.uSync.Core/Mappers/ContentIdMapping.cs
+++ b/Jumoo.uSync.Core/Mappers/ContentIdMapping.cs
@@ -12,7 +12,7 @@ namespace Jumoo.uSync.Core.Mappers
 {
     class ContentIdMapper : IContentMapper
     {
-        public string GetExportValue(PropertyType propType, string value)
+        public string GetExportValue(int dataTypeDefinitionId, string value)
         {
             Dictionary<string, string> replacements = new Dictionary<string, string>();
 
@@ -38,7 +38,7 @@ namespace Jumoo.uSync.Core.Mappers
 
         }
 
-        public string GetImportValue(PropertyType propType, string content)
+        public string GetImportValue(int dataTypeDefinitionId, string content)
         {
             Dictionary<string, string> replacements = new Dictionary<string, string>();
 

--- a/Jumoo.uSync.Core/Mappers/ContentMapperFactory.cs
+++ b/Jumoo.uSync.Core/Mappers/ContentMapperFactory.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace Jumoo.uSync.Core.Mappers
+{
+    public class ContentMapperFactory
+    {
+        public static IContentMapper GetCustomMapper(string typeDefinition)
+        {
+            Type mapperType = Type.GetType(typeDefinition);
+
+            if (mapperType == null)
+            {
+                return null;
+            }
+
+            return Activator.CreateInstance(mapperType) as IContentMapper;
+        }
+
+        public static IContentMapper GetMapper(uSyncContentMapping mapping)
+        {
+            switch (mapping.MappingType)
+            {
+                case ContentMappingType.Content:
+                    return new ContentIdMapper();
+                case ContentMappingType.DataType:
+                    return new ContentDataTypeMapper();
+                case ContentMappingType.DataTypeKeys:
+                    return new ContentDataTypeKeyMapper();
+                case ContentMappingType.Custom:
+                    return ContentMapperFactory.GetCustomMapper(mapping.CustomMappingType);
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/Jumoo.uSync.Core/Mappers/IContentMapper.cs
+++ b/Jumoo.uSync.Core/Mappers/IContentMapper.cs
@@ -9,7 +9,7 @@ namespace Jumoo.uSync.Core.Mappers
 {
     public interface IContentMapper
     {
-        string GetExportValue(PropertyType propType, string value);
-        string GetImportValue(PropertyType propType, string content);
+        string GetExportValue(int dataTypeDefinitionId, string value);
+        string GetImportValue(int dataTypeDefinitionId, string content);
     }
 }

--- a/Jumoo.uSync.Core/Serializers/ContentBaseSerializer.cs
+++ b/Jumoo.uSync.Core/Serializers/ContentBaseSerializer.cs
@@ -85,25 +85,11 @@ namespace Jumoo.uSync.Core.Serializers
             {
                 LogHelper.Debug<Events>("Mapping Content Import: {0} {1}", () => mapping.EditorAlias, () => mapping.MappingType);
 
-                IContentMapper mapper = null;
-
-                switch (mapping.MappingType)
-                {
-                    case ContentMappingType.Content:
-                        mapper = new ContentIdMapper();
-                        break;
-                    case ContentMappingType.DataType:
-                        mapper = new ContentDataTypeMapper();
-                        break;
-                    case ContentMappingType.DataTypeKeys:
-                        mapper = new ContentDataTypeKeyMapper();
-                        break;
-
-                }
+                IContentMapper mapper = ContentMapperFactory.GetMapper(mapping);
 
                 if (mapper != null)
                 {
-                    return mapper.GetImportValue(propType, content);
+                    return mapper.GetImportValue(propType.DataTypeDefinitionId, content);
                 }
             }
 
@@ -165,28 +151,16 @@ namespace Jumoo.uSync.Core.Serializers
             var mapping = uSyncCoreContext.Instance.Configuration.Settings.ContentMappings
                 .SingleOrDefault(x => x.EditorAlias == propType.PropertyEditorAlias);
 
+
             if (mapping != null)
             {
                 LogHelper.Debug<Events>("Mapping Content Export: {0} {1}", () => mapping.EditorAlias, () => mapping.MappingType);
 
-                IContentMapper mapper = null;
-
-                switch (mapping.MappingType)
-                {
-                    case ContentMappingType.Content:
-                        mapper = new ContentIdMapper();
-                        break;
-                    case ContentMappingType.DataType:
-                        mapper = new ContentDataTypeMapper();
-                        break;
-                    case ContentMappingType.DataTypeKeys:
-                        mapper = new ContentDataTypeKeyMapper();
-                        break;
-                }
+                IContentMapper mapper = ContentMapperFactory.GetMapper(mapping);
 
                 if (mapper != null)
                 {
-                    return mapper.GetExportValue(propType, val);
+                    return mapper.GetExportValue(propType.DataTypeDefinitionId, val);
                 }
             }
 

--- a/Jumoo.uSync.Core/uSyncCore.Config
+++ b/Jumoo.uSync.Core/uSyncCore.Config
@@ -88,7 +88,8 @@
     <uSyncContentMapping Alias="Umbraco.DropDownMultiple" Mapping="DataType" />
     <uSyncContentMapping Alias="Umbraco.CheckBoxList" Mapping="DataType" />
 
-
+    <!--Example of using a custom mapping type-->
+    <!--<uSyncContentMapping Alias="Imulus.Archetype" Mapping="Custom" CustomMappingType="Jumoo.uSync.Archetype.ArchetypeContentMapper,Jumoo.uSync.Archetype" />-->
 
   </ContentMappings>
   

--- a/Jumoo.uSync.Core/uSyncCore.Config
+++ b/Jumoo.uSync.Core/uSyncCore.Config
@@ -89,7 +89,7 @@
     <uSyncContentMapping Alias="Umbraco.CheckBoxList" Mapping="DataType" />
 
     <!--Example of using a custom mapping type-->
-    <!--<uSyncContentMapping Alias="Imulus.Archetype" Mapping="Custom" CustomMappingType="Jumoo.uSync.Archetype.ArchetypeContentMapper,Jumoo.uSync.Archetype" />-->
+    <uSyncContentMapping Alias="Imulus.Archetype" Mapping="Custom" CustomMappingType="Jumoo.uSync.Archetype.ArchetypeContentMapper,Jumoo.uSync.Archetype" />
 
   </ContentMappings>
   

--- a/Jumoo.uSync.Core/uSyncCoreConfig.cs
+++ b/Jumoo.uSync.Core/uSyncCoreConfig.cs
@@ -153,6 +153,9 @@ namespace Jumoo.uSync.Core
 
         [XmlAttribute(AttributeName = "Mapping")]
         public ContentMappingType MappingType { get; set; }
+
+        [XmlAttribute(AttributeName = "CustomMappingType")]
+        public string CustomMappingType { get; set; }
     }
 
     public enum ContentMappingType
@@ -160,5 +163,6 @@ namespace Jumoo.uSync.Core
         Content,
         DataType,
         DataTypeKeys,
+        Custom
     }
 }

--- a/Jumoo.uSync.Migrations/Web.config
+++ b/Jumoo.uSync.Migrations/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433

--- a/Umbraco.Site/Config/uSyncCore.config
+++ b/Umbraco.Site/Config/uSyncCore.config
@@ -88,7 +88,8 @@
     <uSyncContentMapping Alias="Umbraco.DropDownMultiple" Mapping="DataType" />
     <uSyncContentMapping Alias="Umbraco.CheckBoxList" Mapping="DataType" />
 
-
+    <!--Example of using a custom mapping type-->
+    <uSyncContentMapping Alias="Imulus.Archetype" Mapping="Custom" CustomMappingType="Jumoo.uSync.Archetype.ArchetypeContentMapper,Jumoo.uSync.Archetype" />
 
   </ContentMappings>
   

--- a/uSync.7.3.sln
+++ b/uSync.7.3.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco.Site", "Umbraco.Site\Umbraco.Site.csproj", "{CDC6D1E7-3387-4F93-A7D2-B666ED655CDE}"
 EndProject

--- a/uSync.7.3.sln
+++ b/uSync.7.3.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jumoo.uSync.Content", "Jumo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jumoo.uSync.Migrations.Chauffeur", "Jumoo.uSync.Migrations.Chauffeur\Jumoo.uSync.Migrations.Chauffeur.csproj", "{D8D04AEA-B0AE-4BAD-93E8-B5E14AB36EB1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jumoo.uSync.Archetype", "Jumoo.uSync.Archetype\Jumoo.uSync.Archetype.csproj", "{DB2DDA62-9CFC-4052-8C06-70AC63F4C431}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{D8D04AEA-B0AE-4BAD-93E8-B5E14AB36EB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D8D04AEA-B0AE-4BAD-93E8-B5E14AB36EB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8D04AEA-B0AE-4BAD-93E8-B5E14AB36EB1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DB2DDA62-9CFC-4052-8C06-70AC63F4C431}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DB2DDA62-9CFC-4052-8C06-70AC63F4C431}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DB2DDA62-9CFC-4052-8C06-70AC63F4C431}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DB2DDA62-9CFC-4052-8C06-70AC63F4C431}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**Archetype** is an Umbraco package that allows for repeating, templated content in a single property.  https://github.com/imulus/Archetype

This pull request adds support for the Export and Import of Archetype properties.

As a side-effect of building this support, the following changes were made to uSync.Core:
- ContentMapperFactory created to handle the selection and creation of the appropriate mapper.  Custom Mappers can be defined in uSyncCore.config and will be resolved at runtime so long as the appropriate assembly is in the bin folder
- IContentMapper has been refactored (simplified?) so that instead of passing in a full PropertyType we only supply the DataTypeDefinitionId as an integer.  This was necessary for Archetype as the child properties are virtual and can never have a PropertyType object representing them.

I have included the Archetype mapper as a separate project.  I wasn't sure how you might want to distribute/support custom mappers within this repository.
