### PR TITLE
Deserialize tabs before properties

### DIFF
--- a/Jumoo.uSync.Core/Serializers/ContentTypeSerializer.cs
+++ b/Jumoo.uSync.Core/Serializers/ContentTypeSerializer.cs
@@ -120,11 +120,11 @@ namespace Jumoo.uSync.Core.Serializers
 
             // _contentTypeService.Save(item);
 
+            // Update Tabs before props -- allows moving props to new tabs in sync
+            DeserializeTabSortOrder((IContentTypeBase)item, node);
+
             // Update Properties
             var msg = DeserializeProperties((IContentTypeBase)item, node);
-
-            // Update Tabs
-            DeserializeTabSortOrder((IContentTypeBase)item, node);
 
             // contenttype specifics..
             var listView = info.Element("IsListView").ValueOrDefault(false);

--- a/Jumoo.uSync.Core/Serializers/MediaTypeSerializer.cs
+++ b/Jumoo.uSync.Core/Serializers/MediaTypeSerializer.cs
@@ -118,9 +118,10 @@ namespace Jumoo.uSync.Core.Serializers
 
             item.SetLazyParentId(new Lazy<int>(() => parentId));
 
-            var msg = DeserializeProperties(item, node);
-
+            // Update Tabs before props -- allows moving props to new tabs in sync
             DeserializeTabSortOrder(item, node);
+
+            var msg = DeserializeProperties(item, node);
 
             // this really needs to happen in a seperate step.
             // DeserializeStructure(item, node);

--- a/Jumoo.uSync.Core/Serializers/MediaTypeSerializer.cs
+++ b/Jumoo.uSync.Core/Serializers/MediaTypeSerializer.cs
@@ -118,9 +118,10 @@ namespace Jumoo.uSync.Core.Serializers
 
             item.SetLazyParentId(new Lazy<int>(() => parentId));
 
-            var msg = DeserializeProperties(item, node);
-
+            // Update Tabs before props -- allows moving props to new tabs in sync
             DeserializeTabSortOrder(item, node);
+
+            var msg = DeserializeProperties(item, node);
 
             DeserializeCompositions(item, info);
             // this really needs to happen in a seperate step.


### PR DESCRIPTION
By deserializing tabs before the properties, we're able to move properties to new tabs during a sync.
