### PR TITLE
HandlerGroups

### DIFF
--- a/Jumoo.uSync.BackOffice/Config/uSyncBackOffice.Config
+++ b/Jumoo.uSync.BackOffice/Config/uSyncBackOffice.Config
@@ -97,7 +97,7 @@
     all the time. 
   -->
   <!-- 
-  <Handlers Group="snapshot" EnableMissing="False"> 
+  <Handlers Group="snapshot" EnableMissing="false"> 
     <HandlerConfig Name="uSync: DataTypeHandler" Enabled="true" />
     <HandlerConfig Name="uSync: TemplateHandler" Enabled="true" />
     <HandlerConfig Name="uSync: ContentTypeHandler" Enabled="true" />

--- a/Jumoo.uSync.BackOffice/Config/uSyncBackOffice.Config
+++ b/Jumoo.uSync.BackOffice/Config/uSyncBackOffice.Config
@@ -50,7 +50,7 @@
       
       you can also set this in the app settings in web.config, 
       
-        <add key="uSync:HandlerGroup" value="default" />
+        <add key="uSync.HandlerGroup" value="default" />
           
       but you need to remove the value in this file if you do that.            
   -->


### PR DESCRIPTION
Hey Kevin,

I found the issue with the Handler groups not working. The comment that I used as reference had a colon instead of a period for   <add key="uSync.HandlerGroup" value="default" />. 

Also, had a weird thing happen when I uncommented the "snapshot" group at the bottom of the uSyncBackoffice.config. When I re-started the website, all the handlers config was striped from the file. Changing it to a lowercase false, seemed to fix it. Not sure what was re-writing the config file though.

Also a couple of things I notice whilst figuring out handler groups:

1. The Enabled attribute doesn't seem to have any effect on each of the HandlerConfig items. I couldn't figure out how to fix, although removing the ones I didn't want works just the same.

2.  A real picky inconsistancy (pointing it out, but feel free to ignore me)... the default group uses for example "uSync: DataTypeHandler" and the Deploy uses Deploy:DataTypeHandler (without a space).


I think the feature is going to be really handy between Dev/Stage/Live sites!