### PR TITLE
Find template (razor) files in subdirectories of Views folder

### DIFF
--- a/Jumoo.uSync.BackOffice/uSyncApplicationEventHandler.cs
+++ b/Jumoo.uSync.BackOffice/uSyncApplicationEventHandler.cs
@@ -1,35 +1,31 @@
 ﻿
 
-namespace Jumoo.uSync.BackOffice
-{
-    using System.IO;
-    using System.Diagnostics;
-
-    using Umbraco.Core;
-    using Umbraco.Core.Logging;
-    using System.Collections.Generic;
-    using System.Linq;
+namespace Jumoo.uSync.BackOffice {
     using Core;
     using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using Umbraco.Core;
+    using Umbraco.Core.IO;
+    using Umbraco.Core.Logging;
+    using Umbraco.Core.Services;
 
-    public class uSyncApplicationEventHandler : ApplicationEventHandler
-    {
-        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
-        {
+    public class uSyncApplicationEventHandler : ApplicationEventHandler {
+        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext) {
             LogHelper.Info<uSyncApplicationEventHandler>("Initializing uSync 73");
 
             var onUaaS = AppDomain.CurrentDomain.GetAssemblies()
                             .Any(a => a.FullName.StartsWith("Concorde.Messaging.Web"));
-            if (onUaaS)
-            {
+            if (onUaaS) {
                 LogHelper.Warn<uSyncApplicationEventHandler>("uSync doesn't run on UaaS, so it will just stop now");
                 return;
             }
 
 
 
-            if (!ApplicationContext.Current.IsConfigured)
-            {
+            if (!ApplicationContext.Current.IsConfigured) {
                 // install and upgrade block, we don't run if umbraco hasn't been configured 
                 LogHelper.Warn<uSyncApplicationEventHandler>("Umbraco isn't configured - uSync aborting");
                 return;
@@ -38,22 +34,20 @@ namespace Jumoo.uSync.BackOffice
             // this version of usync only runs on umbraco 7.3+ 
             //
             var version = Umbraco.Core.Configuration.UmbracoVersion.Current;
-            if (version.Major > 7 || (version.Major == 7 && version.Minor >= 3))
-            {
+            if (version.Major > 7 || (version.Major == 7 && version.Minor >= 3)) {
                 Setup();
-            }
-            else
-            {
+            } else {
                 LogHelper.Warn<uSyncApplicationEventHandler>("This version of uSync isn't compatible with this version of Umbraco.");
             }
         }
 
-        private void Setup()
-        {
+        private void Setup() {
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
             LogHelper.Info<uSyncApplicationEventHandler>("Firing up uSync");
+
+            FileService.SavedTemplate += FileService_SavedTemplate;
 
             // just to make the code readable...
             var uSyncBackOffice = uSyncBackOfficeContext.Instance;
@@ -67,24 +61,20 @@ namespace Jumoo.uSync.BackOffice
                 List<uSyncAction> setupActions = new List<uSyncAction>();
 
                 // some settings based decisions...
-                if (settings.Import)
-                {
+                if (settings.Import) {
                     setupActions.AddRange(uSyncBackOffice.ImportAll());
                 }
 
                 if (settings.ExportAtStartup ||
-                    (settings.ExportOnSave && !Directory.Exists(settings.MappedFolder())))
-                {
+                    (settings.ExportOnSave && !Directory.Exists(settings.MappedFolder()))) {
                     setupActions.AddRange(uSyncBackOffice.ExportAll());
                 }
 
-                if (settings.ExportOnSave)
-                {
+                if (settings.ExportOnSave) {
                     uSyncBackOffice.SetupEvents();
                 }
 
-                if (settings.WatchForFileChanges)
-                {
+                if (settings.WatchForFileChanges) {
                     uSyncFileWatcher.Init(settings.MappedFolder());
                 }
 
@@ -100,18 +90,13 @@ namespace Jumoo.uSync.BackOffice
 
                 sw.Stop();
                 LogHelper.Info<uSyncApplicationEventHandler>("uSync Complete ({0}ms)", () => sw.ElapsedMilliseconds);
-            }
-            catch(Exception ex)
-            {
+            } catch (Exception ex) {
 
-                if (settings.DontThrowErrors)
-                {
+                if (settings.DontThrowErrors) {
                     LogHelper.Info<uSyncApplicationEventHandler>("No Throw errors is set, so uSync won't YSOD");
                     LogHelper.Error<uSyncApplicationEventHandler>("Error During Setup:", ex);
-                }
-                else
-                {
-                    LogHelper.Warn<uSyncApplicationEventHandler>("Errors during Sync: {0} {1}", () => ex.Message, ()=> ex.Source);
+                } else {
+                    LogHelper.Warn<uSyncApplicationEventHandler>("Errors during Sync: {0} {1}", () => ex.Message, () => ex.Source);
                     LogHelper.Warn<uSyncApplicationEventHandler>("Errors during Sync:\n {0}", () => ex.StackTrace);
                     throw new ApplicationException(
                         "uSync encounted an error during setup (which is probibily from an import)\n" +
@@ -120,7 +105,34 @@ namespace Jumoo.uSync.BackOffice
             }
         }
 
+        private void FileService_SavedTemplate(IFileService sender, global::Umbraco.Core.Events.SaveEventArgs<global::Umbraco.Core.Models.ITemplate> e) {
+            foreach (var template in e.SavedEntities) {
+                String foundTemplate = FindTemplate(template.Alias);
+                String GeneratedTemplate = IOHelper.MapPath(string.Format(SystemDirectories.MvcViews + "/{0}.cshtml", template.Alias.ToSafeFileName()));
+                if (!String.IsNullOrEmpty(foundTemplate) && File.ReadAllText(foundTemplate).Equals(template.Content) && File.Exists(GeneratedTemplate) && File.ReadAllText(foundTemplate).Equals(File.ReadAllText(GeneratedTemplate))) {
+                    File.Delete(GeneratedTemplate);
+                }
+            }
+        }
 
-      
+        private String FindTemplate(String alias) {
+            var templatePath = "";
+
+            if (!File.Exists(templatePath)) {
+                var viewsPath = IOHelper.MapPath(SystemDirectories.MvcViews);
+                var directories = Directory.GetDirectories(viewsPath);
+
+                foreach (var directory in directories.Where(x => !x.ToLower().Contains("partials"))) {
+                    var folder = Path.GetFileName(directory);
+                    String relativeFileUrl = string.Format(SystemDirectories.MvcViews + "/{0}/{1}.cshtml", folder, alias.ToSafeFileName());
+                    if (File.Exists(IOHelper.MapPath(relativeFileUrl))) {
+                        templatePath = IOHelper.MapPath(relativeFileUrl);
+                    }
+                }
+            }
+
+            return templatePath;
+        }
+
     }
 }


### PR DESCRIPTION
Allow templates files to be nested inside subdirectories of your MVC Views folder and subsequently to be found by uSync when a template is saved.