### PR TITLE
Set dashboard's external links to new window/tab

### DIFF
--- a/Jumoo.uSync.BackOffice/App_Plugins/uSync/uSyncDashboard.html
+++ b/Jumoo.uSync.BackOffice/App_Plugins/uSync/uSyncDashboard.html
@@ -265,7 +265,7 @@
                                 <input type="radio" ng-model="uSyncMode" value="manual" />
                                 Manual Sync <small>
                                     No automatic imports or saves.
-                                    (why not try <a href="https://our.umbraco.org/projects/developer-tools/usyncSnapshots/">uSync.Snapshots</a>?)
+                                    (why not try <a href="https://our.umbraco.org/projects/developer-tools/usyncSnapshots/" target="_blank">uSync.Snapshots</a>?)
                                 </small>
                             </label>
                             <label class="radio">
@@ -301,7 +301,7 @@
 
             <div id="usync_about" class="tab-pane">
                 <p>
-                    uSync is written and developed by <a href="http://jumoo.uk">Jumoo</a>, and is completely
+                    uSync is written and developed by <a href="http://jumoo.uk" target="_blank">Jumoo</a>, and is completely
                     free and open source.
                 </p>
                 <!-- licencing -->
@@ -336,7 +336,7 @@
                             other people beyond Kevin might answer them
                         </p>
                         <div class="usync-button">
-                            <a href="https://our.umbraco.org/projects/developer-tools/usync/usync/" class="btn btn-success">
+                            <a href="https://our.umbraco.org/projects/developer-tools/usync/usync/" target="_blank" class="btn btn-success">
                                 uSync Forums on our.umbraco.org
                             </a>
                         </div>
@@ -346,7 +346,7 @@
                             the github repo is the place to look.
                         </p>
                         <div class="usync-button">
-                            <a href="https://github.com/KevinJump/uSync/" class="btn btn-default">uSync on github</a>
+                            <a href="https://github.com/KevinJump/uSync/" target="_blank" class="btn btn-default">uSync on github</a>
                         </div>
                         <h4>Complex Stuff via Jumoo</h4>
                         <p>
@@ -373,7 +373,7 @@
                             do it yourself!.
                         </p>
                         <div class="usync-button">
-                            <a href="https://github.com/KevinJump/uSync/" class="btn btn-default">uSync on github</a>
+                            <a href="https://github.com/KevinJump/uSync/" target="_blank" class="btn btn-default">uSync on github</a>
                         </div>
                         <p>
                             Go look at the uSync github repository, fork it, do some code stuff and 
@@ -385,7 +385,7 @@
                             with it, you can still submit bugs to our issue tracker. 
                         </p>
                         <div class="usync-button">
-                            <a href="https://github.com/KevinJump/uSync/issues" class="btn btn-warning btn-lg">Submit an issue</a>
+                            <a href="https://github.com/KevinJump/uSync/issues" target="_blank" class="btn btn-warning btn-lg">Submit an issue</a>
                         </div>
                         <p>
                             We will work with you to get to the bottom of whats going on, and more than

--- a/Jumoo.uSync.BackOffice/App_Plugins/uSync/uSyncDashboard.html
+++ b/Jumoo.uSync.BackOffice/App_Plugins/uSync/uSyncDashboard.html
@@ -343,10 +343,10 @@
                         <h4>uSync GitHub Repository</h4>
                         <p>
                             If you want to get underneath the hood, and look at the code, then
-                            the github repo is the place to look.
+                            the GitHub repo is the place to look.
                         </p>
                         <div class="usync-button">
-                            <a href="https://github.com/KevinJump/uSync/" target="_blank" class="btn btn-default">uSync on github</a>
+                            <a href="https://github.com/KevinJump/uSync/" target="_blank" class="btn btn-default">uSync on GitHub</a>
                         </div>
                         <h4>Complex Stuff via Jumoo</h4>
                         <p>
@@ -373,10 +373,10 @@
                             do it yourself!.
                         </p>
                         <div class="usync-button">
-                            <a href="https://github.com/KevinJump/uSync/" target="_blank" class="btn btn-default">uSync on github</a>
+                            <a href="https://github.com/KevinJump/uSync/" target="_blank" class="btn btn-default">uSync on GitHub</a>
                         </div>
                         <p>
-                            Go look at the uSync github repository, fork it, do some code stuff and 
+                            Go look at the uSync GitHub repository, fork it, do some code stuff and 
                             submit a pull request. We'll merge it in and put it in the next release.
                         </p>
                         <h4>Submit bugs</h4>


### PR DESCRIPTION
I've set the dashboard's external links to open in a new window/tab, as currently they open directly within the back-office.

I've also normalised the references to "GitHub" naming, (guess this is a branding thing?)