### PR TITLE
Action tracker fails to open when readonly

### DIFF
--- a/Jumoo.uSync.BackOffice/Helpers/ActionTracker.cs
+++ b/Jumoo.uSync.BackOffice/Helpers/ActionTracker.cs
@@ -34,14 +34,15 @@ namespace Jumoo.uSync.BackOffice.Helpers
                 try
                 {
                     XmlSerializer serializer = new XmlSerializer(typeof(List<SyncAction>));
-                    using (FileStream fs = new FileStream(_actionFile, FileMode.Open))
+                    using (FileStream fs = new FileStream(_actionFile, FileMode.Open, FileAccess.Read))
                     {
                         _actions = (List<SyncAction>)serializer.Deserialize(fs);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
                     // format fail on load.
+                    LogHelper.Debug<ActionTracker>("Failed to open action file: {0}", () => ex.Message);
                     _actions = new List<SyncAction>();
                 }
             }


### PR DESCRIPTION
fix for action tracker not opening when file is readonly #146 - this is the v7.4 branch *v3.3.x of usync* it needs to also be included in the new v7.7 branch