### PR TITLE
Allow nested templates

### DIFF
--- a/Jumoo.uSync.BackOffice/Handlers/TemplateHandler.cs
+++ b/Jumoo.uSync.BackOffice/Handlers/TemplateHandler.cs
@@ -134,11 +134,8 @@
 
             foreach (var item in e.SavedEntities)
             {
-
-                String foundTemplate = FindTemplate(template.Alias);
-                String GeneratedTemplate = IOHelper.MapPath(string.Format(SystemDirectories.MvcViews + "/{0}.cshtml", template.Alias.ToSafeFileName()));
-                if (!String.IsNullOrEmpty(foundTemplate) && File.ReadAllText(foundTemplate).Equals(template.Content) && File.Exists(GeneratedTemplate) && File.ReadAllText(foundTemplate).Equals(File.ReadAllText(GeneratedTemplate))) {
-                    File.Delete(GeneratedTemplate);
+                if (RemoveRootFileIfFound(item)) {
+                    LogHelper.Info<TemplateHandler>("Removed template file that existed in subfolder and root", () => item.Name);
                 }
 
                 LogHelper.Info<TemplateHandler>("Save: Saving uSync file for item: {0}", () => item.Name);
@@ -154,6 +151,17 @@
                 }
 
             }
+        }
+
+        private Boolean RemoveRootFileIfFound(item) {
+            Boolean removed = false;
+            String foundTemplate = FindTemplate(item.Alias);
+            String GeneratedTemplate = IOHelper.MapPath(string.Format(SystemDirectories.MvcViews + "/{0}.cshtml", item.Alias.ToSafeFileName()));
+            if (!String.IsNullOrEmpty(foundTemplate) && File.ReadAllText(foundTemplate).Equals(item.Content) && File.Exists(GeneratedTemplate) && File.ReadAllText(foundTemplate).Equals(File.ReadAllText(GeneratedTemplate))) {
+                File.Delete(GeneratedTemplate);
+                removed = !removed;
+            }
+            return removed;
         }
 
         private String FindTemplate(String alias) {

--- a/Jumoo.uSync.BackOffice/Handlers/TemplateHandler.cs
+++ b/Jumoo.uSync.BackOffice/Handlers/TemplateHandler.cs
@@ -134,6 +134,13 @@
 
             foreach (var item in e.SavedEntities)
             {
+
+                String foundTemplate = FindTemplate(template.Alias);
+                String GeneratedTemplate = IOHelper.MapPath(string.Format(SystemDirectories.MvcViews + "/{0}.cshtml", template.Alias.ToSafeFileName()));
+                if (!String.IsNullOrEmpty(foundTemplate) && File.ReadAllText(foundTemplate).Equals(template.Content) && File.Exists(GeneratedTemplate) && File.ReadAllText(foundTemplate).Equals(File.ReadAllText(GeneratedTemplate))) {
+                    File.Delete(GeneratedTemplate);
+                }
+
                 LogHelper.Info<TemplateHandler>("Save: Saving uSync file for item: {0}", () => item.Name);
                 var action = ExportToDisk(item, uSyncBackOfficeContext.Instance.Configuration.Settings.Folder);
 
@@ -147,6 +154,25 @@
                 }
 
             }
+        }
+
+        private String FindTemplate(String alias) {
+            var templatePath = "";
+
+            if (!File.Exists(templatePath)) {
+                var viewsPath = IOHelper.MapPath(SystemDirectories.MvcViews);
+                var directories = Directory.GetDirectories(viewsPath);
+
+                foreach (var directory in directories.Where(x => !x.ToLower().Contains("partials"))) {
+                    var folder = Path.GetFileName(directory);
+                    String relativeFileUrl = string.Format(SystemDirectories.MvcViews + "/{0}/{1}.cshtml", folder, alias.ToSafeFileName());
+                    if (File.Exists(IOHelper.MapPath(relativeFileUrl))) {
+                        templatePath = IOHelper.MapPath(relativeFileUrl);
+                    }
+                }
+            }
+
+            return templatePath;
         }
 
         public override uSyncAction ReportItem(string file)

--- a/Jumoo.uSync.BackOffice/uSyncApplicationEventHandler.cs
+++ b/Jumoo.uSync.BackOffice/uSyncApplicationEventHandler.cs
@@ -124,34 +124,5 @@ namespace Jumoo.uSync.BackOffice
                 }
             }
         }
-
-		private void FileService_SavedTemplate(IFileService sender, global::Umbraco.Core.Events.SaveEventArgs<global::Umbraco.Core.Models.ITemplate> e) {
-            foreach (var template in e.SavedEntities) {
-                String foundTemplate = FindTemplate(template.Alias);
-                String GeneratedTemplate = IOHelper.MapPath(string.Format(SystemDirectories.MvcViews + "/{0}.cshtml", template.Alias.ToSafeFileName()));
-                if (!String.IsNullOrEmpty(foundTemplate) && File.ReadAllText(foundTemplate).Equals(template.Content) && File.Exists(GeneratedTemplate) && File.ReadAllText(foundTemplate).Equals(File.ReadAllText(GeneratedTemplate))) {
-                    File.Delete(GeneratedTemplate);
-                }
-            }
-        }
-
-        private String FindTemplate(String alias) {
-            var templatePath = "";
-
-            if (!File.Exists(templatePath)) {
-                var viewsPath = IOHelper.MapPath(SystemDirectories.MvcViews);
-                var directories = Directory.GetDirectories(viewsPath);
-
-                foreach (var directory in directories.Where(x => !x.ToLower().Contains("partials"))) {
-                    var folder = Path.GetFileName(directory);
-                    String relativeFileUrl = string.Format(SystemDirectories.MvcViews + "/{0}/{1}.cshtml", folder, alias.ToSafeFileName());
-                    if (File.Exists(IOHelper.MapPath(relativeFileUrl))) {
-                        templatePath = IOHelper.MapPath(relativeFileUrl);
-                    }
-                }
-            }
-
-            return templatePath;
-        }
     }
 }


### PR DESCRIPTION
For the sake of organizing our template files I wanted to be able to maintain them inside sub folders. The current version doesn't create templates in UM if the template file isn't found in the root of the Views folder.
These edits allows for templates to be maintained in subdirectories of the given MVC views folders. Template files in the root folder will be deleted if the same file is found, based on file name and content, in a subdirectory.