### PR TITLE
Fix the issue where NestedContent cannot be edited within LeBlender after a uSync import.

### DIFF
--- a/Jumoo.uSync.ContentMappers/LeBlenderContentMapper.cs
+++ b/Jumoo.uSync.ContentMappers/LeBlenderContentMapper.cs
@@ -50,7 +50,14 @@ namespace Jumoo.uSync.ContentMappers
                     {
                         LogHelper.Debug<LeBlenderContentMapper>("Value: {0}", () => val.ToString());
                         var dtdValue = val.Value<string>("dataTypeGuid");
-                        var propValue = val["value"].ToString();
+                        string propValue = val["value"].ToString();
+                        var isJson = false;
+                        if (val["value"] is JObject || val["value"] is JArray)
+                        {
+                            isJson = true;
+                            propValue = JsonConvert.SerializeObject(val["value"]);
+                        }
+
                         Guid dtdGuid;
                         if (Guid.TryParse(dtdValue, out dtdGuid))
                         {
@@ -67,6 +74,11 @@ namespace Jumoo.uSync.ContentMappers
                                         mappedValue = mapper.GetExportValue(prop.Id, propValue);
 
                                     val["value"] = mappedValue;
+                                    if (isJson)
+                                    {
+                                        val["value"] = JToken.Parse(mappedValue);
+                                    }
+                                    
 
                                 }
 

--- a/Jumoo.uSync.ContentMappers/LeBlenderContentMapper.cs
+++ b/Jumoo.uSync.ContentMappers/LeBlenderContentMapper.cs
@@ -55,7 +55,6 @@ namespace Jumoo.uSync.ContentMappers
                         if (val["value"] is JObject || val["value"] is JArray)
                         {
                             isJson = true;
-                            propValue = JsonConvert.SerializeObject(val["value"]);
                         }
 
                         Guid dtdGuid;


### PR DESCRIPTION
 It's required to store the mappedValue as a JSON value to avoid double encoding when exporting, which causes Umbraco to fail parsing when trying to edit NestedContent.