### PR TITLE
Fix typo + log output

### DIFF
--- a/Jumoo.uSync.BackOffice/Handlers/LanguageHandler.cs
+++ b/Jumoo.uSync.BackOffice/Handlers/LanguageHandler.cs
@@ -66,7 +66,7 @@
         public uSyncAction ExportToDisk(ILanguage item, string folder)
         {
 
-            LogHelper.Info<LanguageHandler>("Exporting all Langauges");
+            LogHelper.Info<LanguageHandler>("Exporting all Languages");
 
             if (item == null)
                 return uSyncAction.Fail(Path.GetFileName(folder), typeof(ILanguage), "item not set");

--- a/Jumoo.uSync.BackOffice/Helpers/uSyncIOHelper.cs
+++ b/Jumoo.uSync.BackOffice/Helpers/uSyncIOHelper.cs
@@ -53,7 +53,7 @@ namespace Jumoo.uSync.BackOffice.Helpers
             }
             catch(Exception ex)
             {
-                LogHelper.Warn<uSyncEvents>("Failed to save node: ", () => ex.ToString());
+                LogHelper.Warn<uSyncEvents>("Failed to save node: {0}", () => ex.ToString());
             }
         }
 


### PR DESCRIPTION
Small typ.
Also had an issue on export during save, noticed exception string was missing in log file.