### PR TITLE
Fixes a bug introduced in 7.0.12/13 to specify the objectType in calls to EntityService.GetAll

### DIFF
--- a/Jumoo.uSync.Core/Mappers/ContentIdMapping.cs
+++ b/Jumoo.uSync.Core/Mappers/ContentIdMapping.cs
@@ -81,7 +81,7 @@ namespace Jumoo.uSync.Core.Mappers
 
         internal int GetIdFromGuid(Guid guid)
         {
-            var items = ApplicationContext.Current.Services.EntityService.GetAll(guid);
+            var items = ApplicationContext.Current.Services.EntityService.GetAll(UmbracoObjectTypes.Document, new [] { guid } );
             if (items != null && items.Any() && items.FirstOrDefault() != null)
                 return items.FirstOrDefault().Id;
 

--- a/Jumoo.uSync.Core/Serializers/ContentTypeBaseSerializer.cs
+++ b/Jumoo.uSync.Core/Serializers/ContentTypeBaseSerializer.cs
@@ -80,7 +80,7 @@ namespace Jumoo.uSync.Core.Serializers
                 var masterKey = masterNode.Attribute("Key").ValueOrDefault(Guid.Empty);
                 if (masterKey != Guid.Empty)
                 {
-                    var masterEntities = ApplicationContext.Current.Services.EntityService.GetAll(masterKey);
+                    var masterEntities = ApplicationContext.Current.Services.EntityService.GetAll(UmbracoObjectTypes.DocumentType,new [] { masterKey } );
                     if (masterEntities != null && masterEntities.Any() && masterEntities.FirstOrDefault() != null)
                         masterId = masterEntities.FirstOrDefault().Id;
                 }


### PR DESCRIPTION
Code was calling EntityService.GetAll(Guid objectType) which gets all entities of that object type, which is not what was intended.

This PR specifies the object type explicitly, and passes the ID as a second parameter (single-item array).