### PR TITLE
Add AppSetting to override Folder setting from web.config

### DIFF
--- a/Jumoo.uSync.BackOffice/uSyncBackOfficeConfig.cs
+++ b/Jumoo.uSync.BackOffice/uSyncBackOfficeConfig.cs
@@ -88,7 +88,7 @@ namespace Jumoo.uSync.BackOffice
             _settings.Import = WebConfigSetting("uSync.Import", _settings.Import);
             _settings.ExportAtStartup = WebConfigSetting("uSync.ExportAtStartup", _settings.ExportAtStartup);
             _settings.ExportOnSave = WebConfigSetting("uSync.ExportOnSave", _settings.ExportOnSave);
-
+            _settings.Folder = WebConfigSetting("uSync.Folder", _settings.Folder);
             _settings.HandlerGroup = WebConfigSetting("uSync.HandlerGroup", _settings.HandlerGroup);
         }
 


### PR DESCRIPTION
If the uSync:Folder key exists in App setting use that location instead of the one from the uSyncBackOffice.Config File

This enables you to do fancy stuff with configbuilders to change the Folder location in a multi platform environment etc

fixes #257 