### PR TITLE
Adds RelatedLinks content mapper

### DIFF
--- a/Jumoo.uSync.ContentMappers/Jumoo.uSync.ContentMappers.csproj
+++ b/Jumoo.uSync.ContentMappers/Jumoo.uSync.ContentMappers.csproj
@@ -284,6 +284,7 @@
     <Compile Include="NestedContentMapper.cs" />
     <Compile Include="PackageActions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RelatedLinksMapper.cs" />
     <Compile Include="RJPMapper.cs" />
     <Compile Include="StackedContentMapper.cs" />
     <Compile Include="VortoContentMapper.cs" />

--- a/Jumoo.uSync.ContentMappers/RelatedLinksMapper.cs
+++ b/Jumoo.uSync.ContentMappers/RelatedLinksMapper.cs
@@ -1,0 +1,90 @@
+﻿using Jumoo.uSync.Core;
+using Jumoo.uSync.Core.Mappers;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Web.Models;
+
+namespace Jumoo.uSync.ContentMappers
+{
+    public class RelatedLinksMapper : IContentMapper2
+    {
+        private readonly IEntityService _entityService;
+        private readonly JsonSerializerSettings _serializerSettings;
+
+        public RelatedLinksMapper()
+        {
+            _entityService = ApplicationContext.Current.Services.EntityService;
+
+            _serializerSettings = new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                Converters = new List<JsonConverter> { new StringEnumConverter() },
+                Formatting = Formatting.Indented,
+                NullValueHandling = NullValueHandling.Ignore,
+            };
+        }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        public string[] PropertyEditorAliases => new[]
+        {
+            Constants.PropertyEditors.RelatedLinksAlias,
+            Constants.PropertyEditors.RelatedLinks2Alias,
+        };
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        public string GetExportValue(int dataTypeDefinitionId, string value)
+        {
+            var links = JsonConvert.DeserializeObject<List<RelatedLink>>(value, _serializerSettings);
+
+            if (links?.Any() == true)
+            {
+                foreach (var link in links)
+                {
+                    if (link.Type == RelatedLinkType.Internal &&
+                        int.TryParse(link.Link, out var id) == true &&
+                        id > 0)
+                    {
+                        var attempt = _entityService.uSyncGetKeyForId(id);
+                        if (attempt.Success == true)
+                        {
+                            link.Link = attempt.Result.ToString();
+                        }
+                    }
+                }
+            }
+
+            return JsonConvert.SerializeObject(links, _serializerSettings);
+        }
+
+        public string GetImportValue(int dataTypeDefinitionId, string content)
+        {
+            var links = JsonConvert.DeserializeObject<List<RelatedLink>>(content, _serializerSettings);
+
+            if (links?.Any() == true)
+            {
+                foreach (var link in links)
+                {
+                    if (link.Type == RelatedLinkType.Internal &&
+                        Guid.TryParse(link.Link, out var guid) == true &&
+                        guid.Equals(Guid.Empty) == false)
+                    {
+                        var attempt = _entityService.GetIdForKey(guid, UmbracoObjectTypes.Document);
+                        if (attempt.Success)
+                        {
+                            link.Link = attempt.Result.ToString();
+                        }
+                    }
+                }
+            }
+
+            return JsonConvert.SerializeObject(links, _serializerSettings);
+        }
+    }
+}


### PR DESCRIPTION
@KevinJump First and foremost, I appreciate this is now a legacy codebase, so please don't feel obliged to merge and do a patch release. This PR was more that I needed a fix, so sharing it.

On a v7 site that I'm migrating, I hit a scenario where the RelatedLinks editor is being used inside a Grid/LeBlender cell, and uSync is converting the `int` ID to a `Guid`, but it's not being wrapped as a `string` - so the JSON deserializer throws an exception.

By adding in a specific content-mapper for the RelatedLinks editor, this issue is resolved.

_(Given how content-mappers are registered, I am happily using this custom RelatedLinks mapper in our own code library, so no showstoppers for me - and no pressure for you to do a merge/patch.)_