### PR TITLE
Fix Archetype same-alias property issue

### DIFF
--- a/Jumoo.uSync.ContentMappers/ArchetypeContentMapper.cs
+++ b/Jumoo.uSync.ContentMappers/ArchetypeContentMapper.cs
@@ -45,6 +45,7 @@ namespace Jumoo.uSync.ContentMappers
                     if (mapper != null)
                     {
                         typedContent.Fieldsets.AsQueryable()
+                                    .Where(fs => fs.Alias == fieldSet.Alias)
                                     .SelectMany(fs => fs.Properties)
                                     .Where(p => p.Alias == property.Alias)
                                     .ForEach(pm => pm.Value = mapper.GetExportValue(dataType.Id, pm.Value.ToString()));


### PR DESCRIPTION
When there are multiple Archetype fieldset types which contain the same property alias, this causes the property value to get mapped multiple times. For an media picker property, this causes the guids to get distorted.

This change ensures that the mapping is only applied a single time for each fieldset and property.

I appreciate that this package is legacy and you're probably not releasing any more updates to it. I'm adding this PR in case this is useful for others who are going through the process of migrating sites (that use Archetype) from v7 using uSync Migrations.